### PR TITLE
Switch SSE presence tracking to in-memory counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,15 @@
 # Cloud Run Real-time Presence Service
 
-Flask application that records page presence events in Redis and exposes an SSE endpoint for real-time online counts.
+Flask application that exposes an SSE endpoint for real-time online counts without any external data store.
 
 ## Endpoints
 
-- `POST /v1/hit` — accepts `sid`, `path`, `kind` (load/beat/unload) and stores presence data in Redis. Redis write failures are
-  logged with `[HIT_ERR_*]` tags and return `{ "ok": false, "degraded": true }` with HTTP 202 instead of surfacing a 5xx.
-- `GET /sse/online` — streams aggregated online counts every two seconds via Server-Sent Events. Responses disable proxy buffering so the first event is delivered immediately.
+- `GET /sse/online` — streams the current number of connected browsers every two seconds via Server-Sent Events. Responses disable proxy buffering so the first event is delivered immediately.
 - `GET /healthz` — always returns `{ "ok": true }`.
-- `GET /readyz` — returns `{ "ok": true }` when Redis responds to `PING`.
+- `GET /readyz` — always returns `{ "ok": true }`.
 
 ## Environment Variables
 
-- `REDIS_HOST` (required for production)
-- `REDIS_PORT` (default: `6379`)
-- `REDIS_PASSWORD` (optional)
-- `PRESENCE_TTL` (default: `90` seconds)
 - `CORS_ORIGINS` — comma separated list of allowed origins (default: `*`; set to `https://solar-system-82998.bubbleapps.io` once verified).
 - `PORT` (default: `8080`)
 
@@ -28,7 +22,7 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Ensure Redis is available locally when running the server.
+-No external services are required to run the server.
 
 ## Container Image
 
@@ -37,58 +31,14 @@ To build and run the service in a container (e.g. for Cloud Run), use the provid
 
 ```bash
 docker build -t presence-service .
-docker run --rm -p 8080:8080 \
-  -e REDIS_HOST=host.docker.internal \
-  presence-service
+docker run --rm -p 8080:8080 presence-service
 ```
 
 The container entrypoint uses Gunicorn with the threaded worker class so
 Server-Sent Event streams flush promptly while still supporting concurrent
 requests.
 
-## Troubleshooting
+## Cloud Run Deployment Notes
 
-- `/healthz` returning `404` usually means the latest container revision was not
-  deployed; confirm the Cloud Run service is using the new image.
-- `/readyz` returning `{ "ok": false, "error": "..." }` means the
-  application cannot connect to Redis. Verify the `REDIS_HOST`, networking (for
-  example, a VPC connector), and that the instance is in the same region.
-
-## Cloud Run Deployment Checklist
-
-1. Confirm traffic is pinned to the latest revision:
-
-   ```bash
-   gcloud run services describe online --region asia-northeast1 \
-     --format='value(status.url,status.traffic[0].revisionName)'
-   ```
-
-   Reassign traffic in the console or with `gcloud` if the active revision does
-   not match the latest deployment.
-
-2. Enable private Redis access using Serverless VPC Access and direct all
-   egress through it so Memorystore can be reached:
-
-   ```bash
-   gcloud run services update online --region asia-northeast1 \
-     --vpc-connector <YOUR_VPC_CONNECTOR> --vpc-egress all-traffic
-   ```
-
-3. Point the service at the Memorystore instance using its private IP and set
-   the runtime tuning variables:
-
-   ```bash
-   gcloud run services update online --region asia-northeast1 \
-     --set-env-vars \
-       REDIS_HOST=<MEMORYSTORE_PRIVATE_IP>,\
-       REDIS_PORT=6379,\
-       PRESENCE_TTL=90,\
-       CORS_ORIGINS=https://solar-system-82998.bubbleapps.io
-   ```
-
-4. Reduce cold starts and increase concurrency headroom for SSE connections:
-
-   ```bash
-   gcloud run services update online --region asia-northeast1 \
-     --min-instances 1 --concurrency 50
-   ```
+- Configure the Cloud Run service with `max-instances=1` so a single instance maintains the in-memory connection count.
+- Adjust `--concurrency` to the expected number of simultaneous SSE clients (for example `--concurrency 50`).

--- a/app.py
+++ b/app.py
@@ -1,11 +1,11 @@
 import json
 import logging
 import os
+import threading
 import time
-from typing import Dict, Iterable, List, Tuple
+from typing import Iterable
 
 from flask import Flask, Response, jsonify, request, stream_with_context
-import redis
 
 
 logging.basicConfig(level=logging.INFO)
@@ -13,40 +13,31 @@ logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
-redis_host = os.environ.get("REDIS_HOST", "localhost")
-redis_port = int(os.environ.get("REDIS_PORT", "6379"))
-redis_password = os.environ.get("REDIS_PASSWORD")
-
-_redis_pool = redis.ConnectionPool(
-    host=redis_host,
-    port=redis_port,
-    password=redis_password,
-    socket_connect_timeout=1.5,
-    socket_timeout=1.5,
-    health_check_interval=30,
-    decode_responses=True,
-)
-
-
-def _create_redis_client() -> redis.Redis:
-    """Create a Redis client with aggressive timeouts for probe endpoints."""
-
-    return redis.Redis(
-        connection_pool=_redis_pool,
-        decode_responses=True,
-        retry_on_timeout=True,
-    )
-
-
-def _get_redis_client() -> redis.Redis:
-    """Return a Redis client instance bound to the shared connection pool."""
-
-    return _create_redis_client()
-
-presence_ttl = int(os.environ.get("PRESENCE_TTL", "90"))
 raw_origins = os.environ.get("CORS_ORIGINS", "*")
 allowed_origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
 allow_any_origin = "*" in allowed_origins or not allowed_origins
+
+_online_count = 0
+_online_count_lock = threading.Lock()
+
+
+def _increment_online_count() -> int:
+    global _online_count
+    with _online_count_lock:
+        _online_count += 1
+        return _online_count
+
+
+def _decrement_online_count() -> int:
+    global _online_count
+    with _online_count_lock:
+        _online_count = max(0, _online_count - 1)
+        return _online_count
+
+
+def _get_online_count() -> int:
+    with _online_count_lock:
+        return _online_count
 
 
 def _make_cors_preflight_response() -> Response:
@@ -95,152 +86,18 @@ def apply_cors(response: Response) -> Response:
     return response
 
 
-@app.route("/v1/hit", methods=["POST", "OPTIONS"])
-def record_hit() -> Response:
-    if request.method == "OPTIONS":
-        return _make_cors_preflight_response()
-
-    try:
-        payload = request.get_json(force=True)  # type: ignore[no-untyped-call]
-    except Exception:  # noqa: BLE001
-        logger.exception("hit_error: invalid_json")
-        return jsonify({"ok": False, "error": "invalid_json"}), 400
-
-    if not isinstance(payload, dict):
-        logger.error("hit_error: payload_not_object")
-        return jsonify({"ok": False, "error": "invalid_payload"}), 400
-
-    sid = payload.get("sid")
-    path = payload.get("path", "/")
-    event_kind = payload.get("kind")
-
-    if not isinstance(sid, str) or not sid.strip():
-        logger.error("hit_error: missing_sid")
-        return jsonify({"ok": False, "error": "sid_required"}), 400
-    sid = sid.strip()
-
-    if not isinstance(path, str) or not path:
-        path = "/"
-
-    if event_kind not in {"load", "beat", "unload"}:
-        logger.error("hit_error: invalid_kind")
-        return jsonify({"ok": False, "error": "invalid_kind"}), 400
-
-    now = int(time.time())
-    presence_key = f"presence:{sid}"
-    online_key = f"online:{path}"
-
-    try:
-        redis_client = _get_redis_client()
-    except Exception:  # noqa: BLE001
-        logger.exception("[HIT_ERR_CLIENT] sid=%s path=%s kind=%s", sid, path, event_kind)
-        return jsonify({"ok": False, "degraded": True, "errors": ["[HIT_ERR_CLIENT]"]}), 202
-    degraded = False
-    error_tags: List[str] = []
-
-    def _mark_error(tag: str) -> None:
-        nonlocal degraded
-        degraded = True
-        error_tags.append(tag)
-
-    if event_kind == "unload":
-        try:
-            redis_client.delete(presence_key)
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_DELETE]")
-            logger.exception("[HIT_ERR_DELETE] sid=%s path=%s kind=%s", sid, path, event_kind)
-        try:
-            redis_client.zrem(online_key, sid)
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_ZREM]")
-            logger.exception("[HIT_ERR_ZREM] sid=%s path=%s kind=%s", sid, path, event_kind)
-    else:
-        try:
-            redis_client.setex(presence_key, presence_ttl, now)
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_SETEX]")
-            logger.exception("[HIT_ERR_SETEX] sid=%s path=%s kind=%s", sid, path, event_kind)
-        try:
-            redis_client.zadd(online_key, {sid: now})
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_ZADD]")
-            logger.exception("[HIT_ERR_ZADD] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    try:
-        redis_client.zremrangebyscore(online_key, 0, now - presence_ttl)
-    except redis.RedisError:  # noqa: BLE001
-        _mark_error("[HIT_ERR_ZREMRANGE]")
-        logger.exception("[HIT_ERR_ZREMRANGE] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    try:
-        redis_client.expire(online_key, 300)
-    except redis.RedisError:  # noqa: BLE001
-        _mark_error("[HIT_ERR_EXPIRE]")
-        logger.exception("[HIT_ERR_EXPIRE] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    if event_kind == "load":
-        try:
-            redis_client.incr("metrics:pv:total")
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_INCR]")
-            logger.exception("[HIT_ERR_INCR] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    if degraded:
-        logger.warning(
-            "[HIT_DEGRADED] sid=%s path=%s kind=%s stages=%s",
-            sid,
-            path,
-            event_kind,
-            ",".join(error_tags) or "unknown",
-        )
-        response_payload = {"ok": False, "degraded": True}
-        if error_tags:
-            response_payload["errors"] = error_tags
-        return jsonify(response_payload), 202
-
-    logger.info("hit_ok sid=%s kind=%s path=%s", sid, event_kind, path)
-    return jsonify({"ok": True})
-
-
-def _collect_online_stats() -> Dict[str, object]:
-    now = int(time.time())
-    cutoff = now - presence_ttl
-    total = 0
-    per_path: List[Tuple[str, int]] = []
-
-    try:
-        redis_client = _get_redis_client()
-        for key in redis_client.scan_iter(match="online:*"):
-            path = key.split("online:", 1)[1]
-            # Clean up stale members to keep counts accurate
-            redis_client.zremrangebyscore(key, 0, cutoff)
-            count = redis_client.zcard(key)
-            if count > 0:
-                total += count
-                per_path.append((path, count))
-    except redis.RedisError:  # noqa: BLE001
-        logger.exception("sse_error: redis_failure")
-        raise
-
-    per_path.sort(key=lambda item: item[1], reverse=True)
-    top_pages = per_path[:10]
-
-    return {
-        "ts": now,
-        "online_total": total,
-        "top_pages": top_pages,
-    }
-
-
 def _sse_stream() -> Iterable[str]:
-    while True:
-        try:
-            payload = _collect_online_stats()
-        except redis.RedisError:
-            payload = {"ts": int(time.time()), "online_total": 0, "top_pages": []}
-        data = json.dumps(payload, ensure_ascii=False)
-        yield f"data: {data}\n\n"
-        time.sleep(2)
+    current = _increment_online_count()
+    logger.info("sse_connect total=%s", current)
+    try:
+        while True:
+            payload = {"ts": int(time.time()), "online_total": _get_online_count()}
+            data = json.dumps(payload, ensure_ascii=False)
+            yield f"data: {data}\n\n"
+            time.sleep(2)
+    finally:
+        current = _decrement_online_count()
+        logger.info("sse_disconnect remaining=%s", current)
 
 
 @app.route("/sse/online", methods=["GET", "OPTIONS"])
@@ -267,11 +124,6 @@ def healthz() -> Response:
 
 @app.route("/readyz", methods=["GET", "HEAD"])
 def readyz() -> Response:
-    try:
-        _get_redis_client().ping()
-    except redis.RedisError as exc:  # noqa: BLE001
-        logger.exception("readyz_error: redis_unreachable")
-        return jsonify({"ok": False, "error": str(exc)}), 503
     return jsonify({"ok": True})
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flask==3.0.3
-redis==5.0.4
 gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- remove Redis-based presence tracking and count SSE clients in memory per instance
- simplify `/sse/online` to broadcast the in-memory count and update readiness endpoints accordingly
- refresh documentation and dependencies to reflect the new architecture

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68db59ea5d8083329926197ff932f5bb