### PR TITLE
Improve heartbeat pruning and SSE timing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,7 @@
 FROM python:3.11-slim
-
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
-
 WORKDIR /app
-
-COPY requirements.txt ./
+COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-
-COPY . .
-
+COPY app.py .
 ENV PORT=8080
-
-CMD ["gunicorn", "--bind", ":8080", "--workers", "1", "--worker-class", "gthread", "--threads", "8", "--keep-alive", "5", "--timeout", "0", "app:app"]
+CMD ["sh", "-c", "gunicorn -b 0.0.0.0:${PORT:-8080} -w 1 -k gevent -t 0 app:app"]

--- a/README.md
+++ b/README.md
@@ -1,23 +1,40 @@
 # Cloud Run Real-time Presence Service
 
-Flask application that records page presence events in Redis and exposes an SSE endpoint for real-time online counts.
+Flask application that exposes a heartbeat endpoint and SSE stream to track active and
+idle visitors without any external data store. Presence is calculated from recent
+`uid` heartbeats sent by the Bubble application.
 
 ## Endpoints
 
-- `POST /v1/hit` — accepts `sid`, `path`, `kind` (load/beat/unload) and stores presence data in Redis. Redis write failures are
-  logged with `[HIT_ERR_*]` tags and return `{ "ok": false, "degraded": true }` with HTTP 202 instead of surfacing a 5xx.
-- `GET /sse/online` — streams aggregated online counts every two seconds via Server-Sent Events. Responses disable proxy buffering so the first event is delivered immediately.
+- `POST /v1/hit` — accepts `{ "uid": "<user-id>", "last_activity": <unix-seconds> }`
+  and records both the heartbeat receipt time (`last_seen`) and the visitor's most
+  recent interaction (`last_activity`). Intended to be invoked from the visitor page
+  every ~30 seconds.
+- `GET /sse/online` — streams the current list of active and idle visitors every two
+  seconds as Server-Sent Events with payloads like:
+
+  ```json
+  {
+    "ts": 1710000000,
+    "online_total": 5,
+    "active_total": 3,
+    "idle_total": 2,
+    "active_uids": ["alice", "bob", "carol"],
+    "idle_uids": ["dave", "eve"]
+  }
+  ```
+
+  Visitors whose last heartbeat arrived within 60 seconds are treated as online, and
+  those whose `last_activity` is within the most recent five minutes are considered
+  active. Responses disable proxy buffering so events arrive immediately.
 - `GET /healthz` — always returns `{ "ok": true }`.
-- `GET /readyz` — returns `{ "ok": true }` when Redis responds to `PING`.
+- `GET /readyz` — always returns `{ "ok": true }`.
 
 ## Environment Variables
 
-- `REDIS_HOST` (required for production)
-- `REDIS_PORT` (default: `6379`)
-- `REDIS_PASSWORD` (optional)
-- `PRESENCE_TTL` (default: `90` seconds)
-- `CORS_ORIGINS` — comma separated list of allowed origins (default: `*`; set to `https://solar-system-82998.bubbleapps.io` once verified).
 - `PORT` (default: `8080`)
+- `CORS_ALLOW_ORIGIN` — Bubble domain allowed to access the API. Defaults to
+  `https://solar-system-82998.bubbleapps.io`.
 
 ## Development
 
@@ -25,10 +42,10 @@ Install dependencies and run the Flask app:
 
 ```bash
 pip install -r requirements.txt
-python app.py
+gunicorn -b 0.0.0.0:8080 -w 1 -k gevent -t 0 app:app
 ```
 
-Ensure Redis is available locally when running the server.
+No external services are required to run the server.
 
 ## Container Image
 
@@ -37,58 +54,16 @@ To build and run the service in a container (e.g. for Cloud Run), use the provid
 
 ```bash
 docker build -t presence-service .
-docker run --rm -p 8080:8080 \
-  -e REDIS_HOST=host.docker.internal \
-  presence-service
+docker run --rm -p 8080:8080 presence-service
 ```
 
-The container entrypoint uses Gunicorn with the threaded worker class so
-Server-Sent Event streams flush promptly while still supporting concurrent
-requests.
+The container entrypoint runs Gunicorn with a single gevent worker and no timeout so
+Server-Sent Event streams remain open indefinitely while still supporting concurrent
+connections.
 
-## Troubleshooting
+## Cloud Run Deployment Notes
 
-- `/healthz` returning `404` usually means the latest container revision was not
-  deployed; confirm the Cloud Run service is using the new image.
-- `/readyz` returning `{ "ok": false, "error": "..." }` means the
-  application cannot connect to Redis. Verify the `REDIS_HOST`, networking (for
-  example, a VPC connector), and that the instance is in the same region.
-
-## Cloud Run Deployment Checklist
-
-1. Confirm traffic is pinned to the latest revision:
-
-   ```bash
-   gcloud run services describe online --region asia-northeast1 \
-     --format='value(status.url,status.traffic[0].revisionName)'
-   ```
-
-   Reassign traffic in the console or with `gcloud` if the active revision does
-   not match the latest deployment.
-
-2. Enable private Redis access using Serverless VPC Access and direct all
-   egress through it so Memorystore can be reached:
-
-   ```bash
-   gcloud run services update online --region asia-northeast1 \
-     --vpc-connector <YOUR_VPC_CONNECTOR> --vpc-egress all-traffic
-   ```
-
-3. Point the service at the Memorystore instance using its private IP and set
-   the runtime tuning variables:
-
-   ```bash
-   gcloud run services update online --region asia-northeast1 \
-     --set-env-vars \
-       REDIS_HOST=<MEMORYSTORE_PRIVATE_IP>,\
-       REDIS_PORT=6379,\
-       PRESENCE_TTL=90,\
-       CORS_ORIGINS=https://solar-system-82998.bubbleapps.io
-   ```
-
-4. Reduce cold starts and increase concurrency headroom for SSE connections:
-
-   ```bash
-   gcloud run services update online --region asia-northeast1 \
-     --min-instances 1 --concurrency 50
-   ```
+- Configure the Cloud Run service with `max-instances=1` so a single instance maintains
+  the in-memory presence dictionary.
+- Adjust `--concurrency` to the expected number of simultaneous SSE clients (for example
+  `--concurrency 50`).

--- a/app.py
+++ b/app.py
@@ -1,280 +1,186 @@
 import json
-import logging
 import os
 import time
-from typing import Dict, Iterable, List, Tuple
+from dataclasses import dataclass
+from threading import Lock
+from typing import Dict, Iterator, List, Tuple
 
-from flask import Flask, Response, jsonify, request, stream_with_context
-import redis
-
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+from flask import Flask, Response, request, stream_with_context
+from gevent import sleep
 
 app = Flask(__name__)
 
-redis_host = os.environ.get("REDIS_HOST", "localhost")
-redis_port = int(os.environ.get("REDIS_PORT", "6379"))
-redis_password = os.environ.get("REDIS_PASSWORD")
 
-_redis_pool = redis.ConnectionPool(
-    host=redis_host,
-    port=redis_port,
-    password=redis_password,
-    socket_connect_timeout=1.5,
-    socket_timeout=1.5,
-    health_check_interval=30,
-    decode_responses=True,
+@dataclass
+class Presence:
+    last_seen: int
+    last_activity: int
+
+
+_SSE_HEADERS = {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+_CORS_ALLOW_ORIGIN = os.getenv(
+    "CORS_ALLOW_ORIGIN", "https://solar-system-82998.bubbleapps.io"
 )
 
+_LAST_SEEN_TTL_SECONDS = 60
+_ACTIVE_THRESHOLD_SECONDS = 300
+_SSE_BROADCAST_INTERVAL_SECONDS = 2
 
-def _create_redis_client() -> redis.Redis:
-    """Create a Redis client with aggressive timeouts for probe endpoints."""
-
-    return redis.Redis(
-        connection_pool=_redis_pool,
-        decode_responses=True,
-        retry_on_timeout=True,
-    )
+_presence: Dict[str, Presence] = {}
+_lock = Lock()
 
 
-def _get_redis_client() -> redis.Redis:
-    """Return a Redis client instance bound to the shared connection pool."""
-
-    return _create_redis_client()
-
-presence_ttl = int(os.environ.get("PRESENCE_TTL", "90"))
-raw_origins = os.environ.get("CORS_ORIGINS", "*")
-allowed_origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
-allow_any_origin = "*" in allowed_origins or not allowed_origins
+def _now() -> int:
+    return int(time.time())
 
 
-def _make_cors_preflight_response() -> Response:
-    """Return a CORS-compliant response for browser preflight checks."""
+def _update_presence(uid: str, last_activity: int, timestamp: int) -> None:
+    with _lock:
+        _presence[uid] = Presence(last_seen=timestamp, last_activity=last_activity)
 
-    response = Response(status=204)
+
+def _prune_and_snapshot(current_ts: int) -> Tuple[List[str], List[str]]:
+    last_seen_cutoff = current_ts - _LAST_SEEN_TTL_SECONDS
+    active_cutoff = current_ts - _ACTIVE_THRESHOLD_SECONDS
+    with _lock:
+        stale: List[str] = []
+        active: List[str] = []
+        idle: List[str] = []
+
+        for uid, data in list(_presence.items()):
+            if data.last_seen < last_seen_cutoff:
+                stale.append(uid)
+                continue
+
+            if data.last_activity >= active_cutoff:
+                active.append(uid)
+            else:
+                idle.append(uid)
+
+        for uid in stale:
+            _presence.pop(uid, None)
+
+    active.sort()
+    idle.sort()
+    return active, idle
+
+
+def _sse_response(iterable, status: int = 200) -> Response:
+    response = Response(iterable, status=status)
+    for key, value in _SSE_HEADERS.items():
+        response.headers[key] = value
     return response
-
-
-def _resolve_allow_origin(origin: str | None) -> tuple[str | None, bool]:
-    """Determine the appropriate Access-Control-Allow-Origin header value."""
-
-    if allow_any_origin:
-        if origin:
-            return origin, True
-        return "*", True
-    if origin and origin in allowed_origins:
-        return origin, True
-    if allowed_origins:
-        return allowed_origins[0], True
-    return "*", True
 
 
 @app.after_request
-def apply_cors(response: Response) -> Response:
-    origin = request.headers.get("Origin")
-    allow_origin, should_vary = _resolve_allow_origin(origin)
-
-    response.headers["Access-Control-Allow-Origin"] = allow_origin or "*"
-    if allow_origin != "*":
-        response.headers["Access-Control-Allow-Credentials"] = "true"
-
-    if should_vary:
-        existing_vary = response.headers.get("Vary")
-        if existing_vary:
-            if "Origin" not in existing_vary:
-                response.headers["Vary"] = f"{existing_vary}, Origin"
-        else:
-            response.headers["Vary"] = "Origin"
-    else:
-        response.headers.setdefault("Vary", "Origin")
-
-    response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
-    response.headers["Access-Control-Allow-Headers"] = "Content-Type"
-    response.headers["Access-Control-Max-Age"] = "600"
-    return response
+def add_cors_headers(resp: Response) -> Response:
+    request_origin = request.headers.get("Origin")
+    allowed_origin = request_origin or _CORS_ALLOW_ORIGIN
+    resp.headers["Access-Control-Allow-Origin"] = allowed_origin
+    resp.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+    resp.headers["Access-Control-Allow-Headers"] = "Content-Type"
+    resp.headers["Vary"] = "Origin"
+    return resp
 
 
 @app.route("/v1/hit", methods=["POST", "OPTIONS"])
-def record_hit() -> Response:
+def hit():
     if request.method == "OPTIONS":
-        return _make_cors_preflight_response()
+        return Response("", status=204)
+
+    payload = request.get_json(force=True, silent=True) or {}
+    uid = payload.get("uid")
+    last_activity = payload.get("last_activity")
+
+    if not uid:
+        return {"ok": False, "error": "no uid"}, 400
+
+    if last_activity is None:
+        return {"ok": False, "error": "no last_activity"}, 400
 
     try:
-        payload = request.get_json(force=True)  # type: ignore[no-untyped-call]
-    except Exception:  # noqa: BLE001
-        logger.exception("hit_error: invalid_json")
-        return jsonify({"ok": False, "error": "invalid_json"}), 400
+        last_activity_int = int(last_activity)
+    except (TypeError, ValueError):
+        return {"ok": False, "error": "invalid last_activity"}, 400
 
-    if not isinstance(payload, dict):
-        logger.error("hit_error: payload_not_object")
-        return jsonify({"ok": False, "error": "invalid_payload"}), 400
-
-    sid = payload.get("sid")
-    path = payload.get("path", "/")
-    event_kind = payload.get("kind")
-
-    if not isinstance(sid, str) or not sid.strip():
-        logger.error("hit_error: missing_sid")
-        return jsonify({"ok": False, "error": "sid_required"}), 400
-    sid = sid.strip()
-
-    if not isinstance(path, str) or not path:
-        path = "/"
-
-    if event_kind not in {"load", "beat", "unload"}:
-        logger.error("hit_error: invalid_kind")
-        return jsonify({"ok": False, "error": "invalid_kind"}), 400
-
-    now = int(time.time())
-    presence_key = f"presence:{sid}"
-    online_key = f"online:{path}"
-
-    try:
-        redis_client = _get_redis_client()
-    except Exception:  # noqa: BLE001
-        logger.exception("[HIT_ERR_CLIENT] sid=%s path=%s kind=%s", sid, path, event_kind)
-        return jsonify({"ok": False, "degraded": True, "errors": ["[HIT_ERR_CLIENT]"]}), 202
-    degraded = False
-    error_tags: List[str] = []
-
-    def _mark_error(tag: str) -> None:
-        nonlocal degraded
-        degraded = True
-        error_tags.append(tag)
-
-    if event_kind == "unload":
-        try:
-            redis_client.delete(presence_key)
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_DELETE]")
-            logger.exception("[HIT_ERR_DELETE] sid=%s path=%s kind=%s", sid, path, event_kind)
-        try:
-            redis_client.zrem(online_key, sid)
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_ZREM]")
-            logger.exception("[HIT_ERR_ZREM] sid=%s path=%s kind=%s", sid, path, event_kind)
-    else:
-        try:
-            redis_client.setex(presence_key, presence_ttl, now)
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_SETEX]")
-            logger.exception("[HIT_ERR_SETEX] sid=%s path=%s kind=%s", sid, path, event_kind)
-        try:
-            redis_client.zadd(online_key, {sid: now})
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_ZADD]")
-            logger.exception("[HIT_ERR_ZADD] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    try:
-        redis_client.zremrangebyscore(online_key, 0, now - presence_ttl)
-    except redis.RedisError:  # noqa: BLE001
-        _mark_error("[HIT_ERR_ZREMRANGE]")
-        logger.exception("[HIT_ERR_ZREMRANGE] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    try:
-        redis_client.expire(online_key, 300)
-    except redis.RedisError:  # noqa: BLE001
-        _mark_error("[HIT_ERR_EXPIRE]")
-        logger.exception("[HIT_ERR_EXPIRE] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    if event_kind == "load":
-        try:
-            redis_client.incr("metrics:pv:total")
-        except redis.RedisError:  # noqa: BLE001
-            _mark_error("[HIT_ERR_INCR]")
-            logger.exception("[HIT_ERR_INCR] sid=%s path=%s kind=%s", sid, path, event_kind)
-
-    if degraded:
-        logger.warning(
-            "[HIT_DEGRADED] sid=%s path=%s kind=%s stages=%s",
-            sid,
-            path,
-            event_kind,
-            ",".join(error_tags) or "unknown",
-        )
-        response_payload = {"ok": False, "degraded": True}
-        if error_tags:
-            response_payload["errors"] = error_tags
-        return jsonify(response_payload), 202
-
-    logger.info("hit_ok sid=%s kind=%s path=%s", sid, event_kind, path)
-    return jsonify({"ok": True})
+    timestamp = _now()
+    _update_presence(str(uid), last_activity_int, timestamp)
+    return {"ok": True}
 
 
-def _collect_online_stats() -> Dict[str, object]:
-    now = int(time.time())
-    cutoff = now - presence_ttl
-    total = 0
-    per_path: List[Tuple[str, int]] = []
-
-    try:
-        redis_client = _get_redis_client()
-        for key in redis_client.scan_iter(match="online:*"):
-            path = key.split("online:", 1)[1]
-            # Clean up stale members to keep counts accurate
-            redis_client.zremrangebyscore(key, 0, cutoff)
-            count = redis_client.zcard(key)
-            if count > 0:
-                total += count
-                per_path.append((path, count))
-    except redis.RedisError:  # noqa: BLE001
-        logger.exception("sse_error: redis_failure")
-        raise
-
-    per_path.sort(key=lambda item: item[1], reverse=True)
-    top_pages = per_path[:10]
-
-    return {
-        "ts": now,
-        "online_total": total,
-        "top_pages": top_pages,
-    }
+@app.get("/healthz")
+def healthz():
+    return {"ok": True}, 200
 
 
-def _sse_stream() -> Iterable[str]:
-    while True:
-        try:
-            payload = _collect_online_stats()
-        except redis.RedisError:
-            payload = {"ts": int(time.time()), "online_total": 0, "top_pages": []}
-        data = json.dumps(payload, ensure_ascii=False)
-        yield f"data: {data}\n\n"
-        time.sleep(2)
+@app.get("/readyz")
+def readyz():
+    return {"ok": True}, 200
 
 
 @app.route("/sse/online", methods=["GET", "OPTIONS"])
-def stream_online() -> Response:
+def sse_online():
     if request.method == "OPTIONS":
-        return _make_cors_preflight_response()
-    headers = {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache, no-transform",
-        "Connection": "keep-alive",
-        "X-Accel-Buffering": "no",
-    }
-    return Response(
-        stream_with_context(_sse_stream()),
-        headers=headers,
-        mimetype="text/event-stream",
-    )
+        return Response("", status=204)
 
+    def event_stream() -> Iterator[str]:
+        while True:
+            try:
+                now_ts = _now()
+                active_uids, idle_uids = _prune_and_snapshot(now_ts)
+                payload = {
+                    "ts": now_ts,
+                    "online_total": len(active_uids) + len(idle_uids),
+                    "active_total": len(active_uids),
+                    "idle_total": len(idle_uids),
+                    "active_uids": active_uids,
+                    "idle_uids": idle_uids,
+                }
+                yield f"data: {json.dumps(payload)}\n\n"
+                sleep(_SSE_BROADCAST_INTERVAL_SECONDS)
+            except Exception as exc:  # pragma: no cover - defensive guard
+                app.logger.exception("SSE streaming error", exc_info=exc)
+                now_ts = _now()
+                active_uids, idle_uids = _prune_and_snapshot(now_ts)
+                error_payload = {
+                    "ts": now_ts,
+                    "online_total": len(active_uids) + len(idle_uids),
+                    "active_total": len(active_uids),
+                    "idle_total": len(idle_uids),
+                    "active_uids": active_uids,
+                    "idle_uids": idle_uids,
+                    "error": "internal_error",
+                }
+                yield f"data: {json.dumps(error_payload)}\n\n"
+                return
 
-@app.route("/healthz", methods=["GET", "HEAD"])
-def healthz() -> Response:
-    return jsonify({"ok": True})
-
-
-@app.route("/readyz", methods=["GET", "HEAD"])
-def readyz() -> Response:
     try:
-        _get_redis_client().ping()
-    except redis.RedisError as exc:  # noqa: BLE001
-        logger.exception("readyz_error: redis_unreachable")
-        return jsonify({"ok": False, "error": str(exc)}), 503
-    return jsonify({"ok": True})
+        return _sse_response(stream_with_context(event_stream()))
+    except Exception as exc:  # pragma: no cover - defensive route guard
+        app.logger.exception("Unhandled SSE request error", exc_info=exc)
+
+        def error_stream():
+            now_ts = _now()
+            active_uids, idle_uids = _prune_and_snapshot(now_ts)
+            payload = {
+                "ts": now_ts,
+                "online_total": len(active_uids) + len(idle_uids),
+                "active_total": len(active_uids),
+                "idle_total": len(idle_uids),
+                "active_uids": active_uids,
+                "idle_uids": idle_uids,
+                "error": "internal_error",
+            }
+            yield f"data: {json.dumps(payload)}\n\n"
+
+        return _sse_response(error_stream())
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("PORT", "8080"))
-    app.run(host="0.0.0.0", port=port)
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8080")))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flask==3.0.3
-redis==5.0.4
-gunicorn==21.2.0
+gunicorn==22.0.0
+gevent==24.2.1


### PR DESCRIPTION
## Summary
- store per-user `last_seen` and `last_activity` values from `/v1/hit` heartbeats so the presence service can distinguish active versus idle visitors
- stream active and idle user counts plus UID lists from `/sse/online` every two seconds while pruning stale entries in memory

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68db59ea5d8083329926197ff932f5bb